### PR TITLE
Managing window transition

### DIFF
--- a/ChessGameApplication/App.xaml
+++ b/ChessGameApplication/App.xaml
@@ -1,8 +1,7 @@
 ﻿<Application x:Class="ChessGameApplication.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:ChessGameApplication"
-             StartupUri="Windows/MainMenuWindow.xaml">
+             xmlns:local="clr-namespace:ChessGameApplication">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/ChessGameApplication/App.xaml.cs
+++ b/ChessGameApplication/App.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Configuration;
+﻿using ChessGameApplication.Windows.Manager;
+using System.Configuration;
 using System.Data;
 using System.Windows;
 
@@ -9,6 +10,13 @@ namespace ChessGameApplication
     /// </summary>
     public partial class App : Application
     {
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            base.OnStartup(e);
+
+            var manager = new WindowManager();
+            manager.Notify(WindowActions.OpenMainMenu);
+        }
     }
 
 }

--- a/ChessGameApplication/Windows/GameWindow.xaml
+++ b/ChessGameApplication/Windows/GameWindow.xaml
@@ -30,19 +30,18 @@
                     Width="300">
 
             <TextBlock Text="Хід: Білий"
-                       FontSize="24"
                        FontWeight="Bold"
-                       Foreground="White"
                        Margin="0,0,0,30"
-                       HorizontalAlignment="Center"/>
+                       HorizontalAlignment="Center"
+                       Style="{DynamicResource TextBlockStyle}"/>
 
             <Button Content="Зберегти гру"
-                    Style="{StaticResource ButtonStyle}"
+                    Style="{DynamicResource ButtonStyle}"
                     Margin="0,0,0,20"
                     Click="SaveGame_Click"/>
 
             <Button Content="Вийти в меню"
-                    Style="{StaticResource ButtonStyle}"
+                    Style="{DynamicResource ButtonStyle}"
                     Click="BackToMenu_Click"/>
         </StackPanel>
     </Grid>

--- a/ChessGameApplication/Windows/GameWindow.xaml.cs
+++ b/ChessGameApplication/Windows/GameWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using ChessGameApplication.Windows.Manager;
+using System.Text;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
@@ -19,8 +20,11 @@ namespace ChessGameApplication.Windows
         private readonly SolidColorBrush lightCell = new SolidColorBrush(Color.FromRgb(240, 217, 181));
         private readonly SolidColorBrush darkCell = new SolidColorBrush(Color.FromRgb(181, 136, 99));
 
-        public GameWindow()
+        private readonly IWindowManager Manager;
+        public GameWindow(IWindowManager manager)
         {
+            Manager = manager;
+
             InitializeComponent();
             CreateChessBoard();
         }
@@ -47,10 +51,7 @@ namespace ChessGameApplication.Windows
         private void SaveGame_Click(object sender, RoutedEventArgs e) { }
         private void BackToMenu_Click(object sender, RoutedEventArgs e) 
         {
-            var menuWindow = new MainMenuWindow();
-            menuWindow.Show();
-            this.Hide();
-            this.Close();
+            Manager.Notify(this, WindowActions.OpenMainMenu);
         }
     }
 }

--- a/ChessGameApplication/Windows/GameWindow.xaml.cs
+++ b/ChessGameApplication/Windows/GameWindow.xaml.cs
@@ -12,9 +12,6 @@ using System.Windows.Shapes;
 
 namespace ChessGameApplication.Windows
 {
-    /// <summary>
-    /// Interaction logic for GameWindow.xaml
-    /// </summary>
     public partial class GameWindow : Window
     {
         private readonly SolidColorBrush lightCell = new SolidColorBrush(Color.FromRgb(240, 217, 181));
@@ -51,7 +48,7 @@ namespace ChessGameApplication.Windows
         private void SaveGame_Click(object sender, RoutedEventArgs e) { }
         private void BackToMenu_Click(object sender, RoutedEventArgs e) 
         {
-            Manager.Notify(this, WindowActions.OpenMainMenu);
+            Manager.Notify(WindowActions.OpenMainMenu);
         }
     }
 }

--- a/ChessGameApplication/Windows/MainMenuWindow.xaml
+++ b/ChessGameApplication/Windows/MainMenuWindow.xaml
@@ -10,7 +10,7 @@
         Width="1280" Height="720"
         Background="{DynamicResource WindowBackgroundBrush}"
         ResizeMode="CanResizeWithGrip">
-    <Grid Background="{StaticResource GridBackgroundBrush}">
+    <Grid Background="{DynamicResource GridBackgroundBrush}">
 
         <StackPanel VerticalAlignment="Center"
                     HorizontalAlignment="Center"
@@ -25,22 +25,22 @@
                        Style="{DynamicResource TextBlockStyle}"/>
 
             <Button Content="Нова гра"
-                    Style="{StaticResource ButtonStyle}"
+                    Style="{DynamicResource ButtonStyle}"
                     Click="NewGame_Click"
                     Margin="0,0,0,15"/>
 
             <Button Content="Продовжити гру"
-                    Style="{StaticResource ButtonStyle}"
+                    Style="{DynamicResource ButtonStyle}"
                     Click="ContinueGame_Click"
                     Margin="0,0,0,15"/>
 
             <Button Content="Налаштування"
-                    Style="{StaticResource ButtonStyle}"
+                    Style="{DynamicResource ButtonStyle}"
                     Click="Settings_Click"
                     Margin="0,0,0,15"/>
 
             <Button Content="Вихід"
-                    Style="{StaticResource ButtonStyle}"
+                    Style="{DynamicResource ButtonStyle}"
                     Click="Exit_Click"
                     Margin="0,0,0,15"/>
         </StackPanel>

--- a/ChessGameApplication/Windows/MainMenuWindow.xaml.cs
+++ b/ChessGameApplication/Windows/MainMenuWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Win32;
+﻿using ChessGameApplication.Windows.Manager;
+using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -18,16 +19,16 @@ namespace ChessGameApplication.Windows
 {
     public partial class MainMenuWindow : Window
     {
-        public MainMenuWindow()
+        private readonly IWindowManager Manager;
+        public MainMenuWindow(IWindowManager manager)
         {
+            Manager = manager;
+
             InitializeComponent();
         }
         private void NewGame_Click(object sender, RoutedEventArgs e)
         {
-            var game = new GameWindow();
-            game.Show();
-            this.Hide();
-            this.Close();
+            Manager.Notify(WindowActions.OpenGame);
         }
 
         private void ContinueGame_Click(object sender, RoutedEventArgs e)
@@ -37,15 +38,12 @@ namespace ChessGameApplication.Windows
 
         private void Settings_Click(object sender, RoutedEventArgs e)
         {
-            var setting = new SettingsWindow();
-            setting.Show();
-            this.Hide();
-            this.Close();
+            Manager.Notify(WindowActions.OpenSettings);
         }
 
         private void Exit_Click(object sender, RoutedEventArgs e)
         {
-            Application.Current.Shutdown();
+            Manager.Notify(WindowActions.Exit);
         }
     }
 }

--- a/ChessGameApplication/Windows/Manager/IWindowManager.cs
+++ b/ChessGameApplication/Windows/Manager/IWindowManager.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace ChessGameApplication.Windows.Manager
+{
+    public interface IWindowManager
+    {
+        void Notify(Window sender, string action);
+    }
+}

--- a/ChessGameApplication/Windows/Manager/IWindowManager.cs
+++ b/ChessGameApplication/Windows/Manager/IWindowManager.cs
@@ -9,6 +9,6 @@ namespace ChessGameApplication.Windows.Manager
 {
     public interface IWindowManager
     {
-        void Notify(Window sender, WindowActions action);
+        void Notify(WindowActions action);
     }
 }

--- a/ChessGameApplication/Windows/Manager/WindowActions.cs
+++ b/ChessGameApplication/Windows/Manager/WindowActions.cs
@@ -3,12 +3,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Windows;
 
 namespace ChessGameApplication.Windows.Manager
 {
-    public interface IWindowManager
+    public enum WindowActions
     {
-        void Notify(Window sender, WindowActions action);
+        OpenMainMenu,
+        OpenGame,
+        OpenSettings,
+        Exit
     }
 }

--- a/ChessGameApplication/Windows/Manager/WindowManager.cs
+++ b/ChessGameApplication/Windows/Manager/WindowManager.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace ChessGameApplication.Windows.Manager
+{
+    public class WindowManager : IWindowManager
+    {
+        private Window? CurrentWindow;
+
+        private readonly GameWindow gameWindow;
+        private readonly MainMenuWindow mainMenuWindow;
+        private readonly SettingsWindow settingsWindow;
+
+        public WindowManager()
+        {
+            gameWindow = new GameWindow(this);
+            mainMenuWindow = new MainMenuWindow(this);
+            settingsWindow = new SettingsWindow(this);
+        }
+        public void Notify(Window sender, string action)
+        {
+            switch (action)
+            {
+                case "OpenMainMenu":
+                    SwitchWindow(mainMenuWindow);
+                    break;
+                case "OpenGame":
+                    SwitchWindow(gameWindow);
+                    break;
+                case "OpenSettings":
+                    SwitchWindow(settingsWindow);
+                    break;
+                case "Exit":
+                    Application.Current.Shutdown();
+                    break;
+                default:
+                    throw new ArgumentException($"Невідома дія: {action}");
+            }
+        }
+
+        private void SwitchWindow(Window newWindow)
+        {
+            if (CurrentWindow == newWindow)
+                return;
+
+            CurrentWindow?.Hide();
+            CurrentWindow = newWindow;
+            CurrentWindow.Show();
+        }
+    }
+}

--- a/ChessGameApplication/Windows/Manager/WindowManager.cs
+++ b/ChessGameApplication/Windows/Manager/WindowManager.cs
@@ -21,7 +21,7 @@ namespace ChessGameApplication.Windows.Manager
             mainMenuWindow = new MainMenuWindow(this);
             settingsWindow = new SettingsWindow(this);
         }
-        public void Notify(Window sender, WindowActions action)
+        public void Notify(WindowActions action)
         {
             switch (action)
             {

--- a/ChessGameApplication/Windows/Manager/WindowManager.cs
+++ b/ChessGameApplication/Windows/Manager/WindowManager.cs
@@ -21,20 +21,20 @@ namespace ChessGameApplication.Windows.Manager
             mainMenuWindow = new MainMenuWindow(this);
             settingsWindow = new SettingsWindow(this);
         }
-        public void Notify(Window sender, string action)
+        public void Notify(Window sender, WindowActions action)
         {
             switch (action)
             {
-                case "OpenMainMenu":
+                case WindowActions.OpenMainMenu:
                     SwitchWindow(mainMenuWindow);
                     break;
-                case "OpenGame":
+                case WindowActions.OpenGame:
                     SwitchWindow(gameWindow);
                     break;
-                case "OpenSettings":
+                case WindowActions.OpenSettings:
                     SwitchWindow(settingsWindow);
                     break;
-                case "Exit":
+                case WindowActions.Exit:
                     Application.Current.Shutdown();
                     break;
                 default:

--- a/ChessGameApplication/Windows/SettingsWindow.xaml.cs
+++ b/ChessGameApplication/Windows/SettingsWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using ChessGameApplication.JsonModels;
+using ChessGameApplication.Windows.Manager;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -20,8 +21,10 @@ namespace ChessGameApplication.Windows
     public partial class SettingsWindow : Window
     {
         private AppSettings Settings;
-        public SettingsWindow()
+        private readonly IWindowManager Manager;
+        public SettingsWindow(IWindowManager manager)
         {
+            Manager = manager;
             Settings = SettingsManager.Instance.Settings!;
 
             InitializeComponent();
@@ -85,10 +88,7 @@ namespace ChessGameApplication.Windows
 
         private void BackToMenu_Click(object sender, RoutedEventArgs e)
         {
-            var menu = new MainMenuWindow();
-            menu.Show();
-
-            this.Close();
+            Manager.Notify(WindowActions.OpenMainMenu);
         }
     }
 }


### PR DESCRIPTION
### Created WindowManager with Mediator pattern to switching between windows.

## Key Changes:
1. Implemented Mediator pattern
+ Created [WindowManager](https://github.com/Shadocl-low/ChessGame/blob/f62f707921f75102ea49afc4b4c61fe609e34b1d/ChessGameApplication/Windows/Manager/WindowManager.cs) as mediator. All windows are independent: they know only about manager, not specific window.
2. Simple window changing
+ Can switch window through [one manager method](https://github.com/Shadocl-low/ChessGame/blob/f62f707921f75102ea49afc4b4c61fe609e34b1d/ChessGameApplication/Windows/MainMenuWindow.xaml.cs#L39-L42)
3. Created Enum with actions
+ Written [WindowActions enum](https://github.com/Shadocl-low/ChessGame/blob/f62f707921f75102ea49afc4b4c61fe609e34b1d/ChessGameApplication/Windows/Manager/WindowActions.cs) for simple command calling

## Benefits:
+ More comfort for developer with managing windows transitions.
+ Easy to add new window transition