### PR TITLE
Rendering Board in Window

### DIFF
--- a/ChessGameApplication/Game/GameManager.cs
+++ b/ChessGameApplication/Game/GameManager.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ChessGameApplication.Game.Figures;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,13 +7,13 @@ using System.Threading.Tasks;
 
 namespace ChessGameApplication.Game
 {
-    public class Game
+    public class GameManager
     {
         public Board Board { get; private set; }
         public PieceColor CurrentTurn { get; private set; } = PieceColor.White;
         public bool IsGameOver { get; private set; }
 
-        public Game()
+        public GameManager()
         {
             Board = new Board();
             StartNewGame();
@@ -58,6 +59,10 @@ namespace ChessGameApplication.Game
             {
                 CurrentTurn = PieceColor.White;
             }
+        }
+        public Piece? GetPiece(Position position)
+        {
+            return Board.GetPieceAt(position);
         }
     }
 }

--- a/ChessGameApplication/Windows/GameWindow.xaml.cs
+++ b/ChessGameApplication/Windows/GameWindow.xaml.cs
@@ -1,4 +1,6 @@
-﻿using ChessGameApplication.Windows.Manager;
+﻿using ChessGameApplication.Game.Figures;
+using ChessGameApplication.Game;
+using ChessGameApplication.Windows.Manager;
 using System.Text;
 using System.Windows;
 using System.Windows.Controls;
@@ -18,9 +20,11 @@ namespace ChessGameApplication.Windows
         private readonly SolidColorBrush darkCell = new SolidColorBrush(Color.FromRgb(181, 136, 99));
 
         private readonly IWindowManager Manager;
+        private readonly GameManager Game;
         public GameWindow(IWindowManager manager)
         {
             Manager = manager;
+            Game = new GameManager();
 
             InitializeComponent();
             CreateChessBoard();
@@ -40,6 +44,19 @@ namespace ChessGameApplication.Windows
                         BorderBrush = Brushes.Black
                     };
 
+                    Piece? piece = Game.GetPiece(new Position(row, col));
+                    if (piece != null)
+                    {
+                        var text = new TextBlock
+                        {
+                            Text = GetPieceSymbol(piece),
+                            FontSize = 32,
+                            HorizontalAlignment = HorizontalAlignment.Center,
+                            VerticalAlignment = VerticalAlignment.Center
+                        };
+                        cell.Child = text;
+                    }
+
                     ChessBoard.Children.Add(cell);
                 }
             }
@@ -49,6 +66,25 @@ namespace ChessGameApplication.Windows
         private void BackToMenu_Click(object sender, RoutedEventArgs e) 
         {
             Manager.Notify(WindowActions.OpenMainMenu);
+        }
+        private string GetPieceSymbol(Piece piece)
+        {
+            return piece switch
+            {
+                Pawn   p when p.Color == PieceColor.White => "♙",
+                Rook   r when r.Color == PieceColor.White => "♖",
+                Knight k when k.Color == PieceColor.White => "♘",
+                Bishop b when b.Color == PieceColor.White => "♗",
+                Queen  q when q.Color == PieceColor.White => "♕",
+                King   k when k.Color == PieceColor.White => "♔",
+                Pawn   p when p.Color == PieceColor.Black => "♟",
+                Rook   r when r.Color == PieceColor.Black => "♜",
+                Knight k when k.Color == PieceColor.Black => "♞",
+                Bishop b when b.Color == PieceColor.Black => "♝",
+                Queen  q when q.Color == PieceColor.Black => "♛",
+                King   k when k.Color == PieceColor.Black => "♚",
+                _ => ""
+            };
         }
     }
 }


### PR DESCRIPTION
### Now Board's content rendering on the GameWindow.

## Key Changes:
1. Renamed Game class
+ Now It's [GameManager](https://github.com/Shadocl-low/ChessGame/blob/f7eec4bf51d04184ec34519cfcc9535bbc960d29/ChessGameApplication/Game/GameManager.cs)
2. Updated [CreateChessBoard](https://github.com/Shadocl-low/ChessGame/blob/f7eec4bf51d04184ec34519cfcc9535bbc960d29/ChessGameApplication/Windows/GameWindow.xaml.cs#L33-L63) method
+ Now GameWindow initializes GameManager class for working with board and pieces. Updated method sets textBlock for cell.
3. Pieces appearance
+ Created [GetPieceSymbol](https://github.com/Shadocl-low/ChessGame/blob/f7eec4bf51d04184ec34519cfcc9535bbc960d29/ChessGameApplication/Windows/GameWindow.xaml.cs#L70-L88) method that gives text alternative for a piece

## Benefits:
+ Functional classes connected with UI.
+ Simple Pieces appearance.