### PR TITLE
Fixed Pawn first move pattern

### DIFF
--- a/ChessGameApplication/Game/Figures/Pawn.cs
+++ b/ChessGameApplication/Game/Figures/Pawn.cs
@@ -15,14 +15,14 @@ namespace ChessGameApplication.Game.Figures
             var moves = new List<Position>();
 
             int direction = Color == PieceColor.White ? -1 : 1;
-            int startRow = Color == PieceColor.White ? 6 : 1;
+            int startColumn = Color == PieceColor.White ? 6 : 1;
 
             var forward = Position.Add(0, direction);
             if (board.IsInsideBoard(forward) && board.IsEmpty(forward))
                 moves.Add(forward);
 
             var doubleForward = Position.Add(0, direction * 2);
-            if (Position.Row == startRow && board.IsEmpty(forward) && board.IsEmpty(doubleForward))
+            if (Position.Column == startColumn && board.IsEmpty(forward) && board.IsEmpty(doubleForward))
                 moves.Add(doubleForward);
 
             foreach (int dx in new[] { -1, 1 })

--- a/ChessGameApplication/Windows/GameWindow.xaml.cs
+++ b/ChessGameApplication/Windows/GameWindow.xaml.cs
@@ -23,7 +23,6 @@ namespace ChessGameApplication.Windows
         private readonly SolidColorBrush darkCell = new SolidColorBrush(Color.FromRgb(181, 136, 99));
         private Position? _selectedPosition;
         private Dictionary<Position, Border> positionToCellMap = new();
-        private List<Position> allowedMoves = new();
 
         private readonly IWindowManager Manager;
         private readonly GameManager Game;
@@ -178,7 +177,6 @@ namespace ChessGameApplication.Windows
                 cell.Background = GetOriginalCellColor((Position)cell.Tag);
                 cell.BorderThickness = new Thickness(0.5);
             }
-            allowedMoves.Clear();
         }
         private Brush GetOriginalCellColor(Position pos)
         {


### PR DESCRIPTION
### Fixed a bug with Pawn's first move

## Key Changes:
1. Changed variable
+ Variable [startRow](https://github.com/Shadocl-low/ChessGame/blob/0956c161a7cd952127b23bae5d29b58020639103/ChessGameApplication/Game/Figures/Pawn.cs#L18) was renamed into startColumn.
+ [Position check](https://github.com/Shadocl-low/ChessGame/blob/0956c161a7cd952127b23bae5d29b58020639103/ChessGameApplication/Game/Figures/Pawn.cs#L25) was also changed.

## Benefits:
+ Pawn movement according to the rules.