### PR TITLE
Updated cell highlighting when piece can attack an enemy

### DIFF
--- a/ChessGameApplication/Game/GameManager.cs
+++ b/ChessGameApplication/Game/GameManager.cs
@@ -70,5 +70,9 @@ namespace ChessGameApplication.Game
         {
             return (List<Position>)piece.GetAvailableMoves(Board);
         }
+        public bool IsEnemyPiece(Position pos)
+        {
+            return Board.IsEnemyPiece(pos, CurrentTurn);
+        }
     }
 }

--- a/ChessGameApplication/Windows/GameWindow.xaml.cs
+++ b/ChessGameApplication/Windows/GameWindow.xaml.cs
@@ -137,6 +137,8 @@ namespace ChessGameApplication.Windows
         private void HighlightCells(Piece piece)
         {
             var positions = Game.GetPieceMoves(piece);
+            var cellBgFree = new SolidColorBrush(Color.FromArgb(100, 50, 200, 50));
+            var cellBgEnemy = new SolidColorBrush(Color.FromArgb(100, 200, 100, 50));
 
             if (positionToCellMap.TryGetValue(piece.Position, out var border))
             {
@@ -147,7 +149,7 @@ namespace ChessGameApplication.Windows
             {
                 if (positionToCellMap.TryGetValue(pos, out border))
                 {
-                    border.Background = new SolidColorBrush(Color.FromArgb(100, 50, 200, 50));
+                    border.Background = Game.IsEnemyPiece(pos) ? cellBgEnemy : cellBgFree;
                 }
             }
         }


### PR DESCRIPTION
### Updated GameWindow method for better user experience.

## Key Changes:
1. Updated [HighlightCells](https://github.com/Shadocl-low/ChessGame/blob/dc5ed754a018eec21f11c710171ba1db0d159bca/ChessGameApplication/Windows/GameWindow.xaml.cs#L137-L155) method
+ If one of the pieces possible moves can attack an enemy it would be highlighted red.

## Benefits:
+ Better design for user.
+ Easier for user to read battle field.