### PR TITLE
Refactoring SettingsManager. Added work with Window mode

### DIFF
--- a/ChessGameApplication/Game/Board.cs
+++ b/ChessGameApplication/Game/Board.cs
@@ -24,15 +24,15 @@ namespace ChessGameApplication.Game
             };
 
             foreach (var (type, x, y) in startingPieces)
-                PlacePiece((Piece)Activator.CreateInstance(type, PieceColor.Black, new Position(x, y), ImageStrategy)!, new Position(x, y));
+                PlacePiece((Piece)Activator.CreateInstance(type, PieceColor.Black, new Position(x, y))!, new Position(x, y));
 
             foreach (var (type, x, y) in startingPieces)
-                PlacePiece((Piece)Activator.CreateInstance(type, PieceColor.White, new Position(x, 7), ImageStrategy)!, new Position(x, 7));
+                PlacePiece((Piece)Activator.CreateInstance(type, PieceColor.White, new Position(x, 7))!, new Position(x, 7));
 
             for (int x = 0; x < 8; x++)
             {
-                PlacePiece(new Pawn(PieceColor.Black, new Position(x, 1), ImageStrategy), new Position(x, 1));
-                PlacePiece(new Pawn(PieceColor.White, new Position(x, 6), ImageStrategy), new Position(x, 6));
+                PlacePiece(new Pawn(PieceColor.Black, new Position(x, 1)), new Position(x, 1));
+                PlacePiece(new Pawn(PieceColor.White, new Position(x, 6)), new Position(x, 6));
             }
         }
         public void SetStrategy(IPieceImageStrategy imageStrategy)
@@ -99,6 +99,12 @@ namespace ChessGameApplication.Game
         public bool IsKingCaptured(PieceColor color)
         {
             return !Squares.Cast<Piece?>().Any(p => p is King k && k.Color == color);
+        }
+        public IEnumerable<Piece> GetAllPieces()
+        {
+            return Squares.Cast<Piece?>()
+                         .Where(piece => piece != null)
+                         .Select(piece => piece!);
         }
     }
 }

--- a/ChessGameApplication/Game/Figures/Bishop.cs
+++ b/ChessGameApplication/Game/Figures/Bishop.cs
@@ -9,7 +9,7 @@ namespace ChessGameApplication.Game.Figures
 {
     public class Bishop : Piece
     {
-        public Bishop(PieceColor color, Position position, IPieceImageStrategy imageStrategy) : base(color, position, imageStrategy) { }
+        public Bishop(PieceColor color, Position position) : base(color, position) { }
 
         public override List<Position> GetAvailableMoves(Board board)
         {

--- a/ChessGameApplication/Game/Figures/King.cs
+++ b/ChessGameApplication/Game/Figures/King.cs
@@ -9,7 +9,7 @@ namespace ChessGameApplication.Game.Figures
 {
     public class King : Piece
     {
-        public King(PieceColor color, Position position, IPieceImageStrategy imageStrategy) : base(color, position, imageStrategy) { }
+        public King(PieceColor color, Position position) : base(color, position) { }
 
         public override List<Position> GetAvailableMoves(Board board)
         {

--- a/ChessGameApplication/Game/Figures/Knight.cs
+++ b/ChessGameApplication/Game/Figures/Knight.cs
@@ -9,7 +9,7 @@ namespace ChessGameApplication.Game.Figures
 {
     public class Knight : Piece
     {
-        public Knight(PieceColor color, Position position, IPieceImageStrategy imageStrategy) : base(color, position, imageStrategy) { }
+        public Knight(PieceColor color, Position position) : base(color, position) { }
 
         public override List<Position> GetAvailableMoves(Board board)
         {

--- a/ChessGameApplication/Game/Figures/Pawn.cs
+++ b/ChessGameApplication/Game/Figures/Pawn.cs
@@ -9,7 +9,7 @@ namespace ChessGameApplication.Game.Figures
 {
     public class Pawn : Piece
     {
-        public Pawn(PieceColor color, Position position, IPieceImageStrategy imageStrategy) : base(color, position, imageStrategy) { }
+        public Pawn(PieceColor color, Position position) : base(color, position) { }
 
         public override List<Position> GetAvailableMoves(Board board)
         {

--- a/ChessGameApplication/Game/Figures/Piece.cs
+++ b/ChessGameApplication/Game/Figures/Piece.cs
@@ -15,12 +15,15 @@ namespace ChessGameApplication.Game.Figures
         public Position Position { get; set; }
         public ImageSource? Image { get; protected set; }
 
-        protected Piece(PieceColor color, Position position, IPieceImageStrategy imageStrategy)
+        protected Piece(PieceColor color, Position position)
         {
             Color = color;
             Position = position;
-            Image = imageStrategy.GetImageForPiece(this);
         }
         public abstract IEnumerable<Position> GetAvailableMoves(Board board);
+        public void UpdateImage(IPieceImageStrategy strategy)
+        {
+            Image = strategy.GetImageForPiece(this);
+        }
     }
 }

--- a/ChessGameApplication/Game/Figures/Queen.cs
+++ b/ChessGameApplication/Game/Figures/Queen.cs
@@ -9,7 +9,7 @@ namespace ChessGameApplication.Game.Figures
 {
     public class Queen : Piece
     {
-        public Queen(PieceColor color, Position position, IPieceImageStrategy imageStrategy) : base(color, position, imageStrategy) { }
+        public Queen(PieceColor color, Position position) : base(color, position) { }
 
         public override List<Position> GetAvailableMoves(Board board)
         {

--- a/ChessGameApplication/Game/Figures/Rook.cs
+++ b/ChessGameApplication/Game/Figures/Rook.cs
@@ -9,7 +9,7 @@ namespace ChessGameApplication.Game.Figures
 {
     public class Rook : Piece
     {
-        public Rook(PieceColor color, Position position, IPieceImageStrategy imageStrategy) : base(color, position, imageStrategy) { }
+        public Rook(PieceColor color, Position position) : base(color, position) { }
 
         public override IEnumerable<Position> GetAvailableMoves(Board board)
         {

--- a/ChessGameApplication/Game/GameManager.cs
+++ b/ChessGameApplication/Game/GameManager.cs
@@ -15,8 +15,10 @@ namespace ChessGameApplication.Game
         private IPieceImageStrategy? _currentStrategy;
         public bool IsGameOver { get; private set; }
 
-        public GameManager()
+        public GameManager(IPieceImageStrategy imageStrategy)
         {
+            _currentStrategy = imageStrategy;
+
             Board = new Board();
 
             StartNewGame();
@@ -26,6 +28,8 @@ namespace ChessGameApplication.Game
             Board.Initialize(); 
             CurrentTurn = PieceColor.White;
             IsGameOver = false;
+
+            UpdateImageStrategy(_currentStrategy!);
         }
 
         public bool TryMakeMove(Position from, Position to)

--- a/ChessGameApplication/Game/GameManager.cs
+++ b/ChessGameApplication/Game/GameManager.cs
@@ -12,12 +12,12 @@ namespace ChessGameApplication.Game
     {
         public Board Board { get; private set; }
         public PieceColor CurrentTurn { get; private set; } = PieceColor.White;
+        private IPieceImageStrategy? _currentStrategy;
         public bool IsGameOver { get; private set; }
 
-        public GameManager(IPieceImageStrategy imageStrategy)
+        public GameManager()
         {
             Board = new Board();
-            Board.SetStrategy(imageStrategy);
 
             StartNewGame();
         }
@@ -73,6 +73,15 @@ namespace ChessGameApplication.Game
         public bool IsEnemyPiece(Position pos)
         {
             return Board.IsEnemyPiece(pos, CurrentTurn);
+        }
+        public void UpdateImageStrategy(IPieceImageStrategy newStrategy)
+        {
+            _currentStrategy = newStrategy;
+
+            foreach (var piece in Board.GetAllPieces())
+            {
+                piece.UpdateImage(_currentStrategy);
+            }
         }
     }
 }

--- a/ChessGameApplication/SettingsManager.cs
+++ b/ChessGameApplication/SettingsManager.cs
@@ -15,6 +15,10 @@ namespace ChessGameApplication
     {
         private static readonly string SettingsFilePath = "appsettings.json";
 
+        public event Action<string> ThemeChanged;
+        public event Action<string> WindowModeChanged;
+        public event Action<IPieceImageStrategy> PieceSkinChanged;
+
         public AppSettings? Settings { get; private set; }
         private readonly JsonSerializerOptions jsonSerializerOptions = new() { WriteIndented = true };
 
@@ -45,16 +49,23 @@ namespace ChessGameApplication
         {
             Instance.Settings!.Theme = theme;
             Instance.Save();
+
+            Instance.ThemeChanged?.Invoke(theme);
         }
         public static void SetWindowMode(string windowMode)
         {
             Instance.Settings!.WindowMode = windowMode;
             Instance.Save();
+
+            Instance.WindowModeChanged?.Invoke(windowMode);
         }
         public static void SetPieceSkin(string skin)
         {
             Instance.Settings!.PieceSkin = skin;
             Instance.Save();
+
+            var strategy = GetImageStrategy();
+            Instance.PieceSkinChanged?.Invoke(strategy);
         }
         public static IPieceImageStrategy GetImageStrategy()
         {

--- a/ChessGameApplication/SettingsManager.cs
+++ b/ChessGameApplication/SettingsManager.cs
@@ -15,9 +15,8 @@ namespace ChessGameApplication
     {
         private static readonly string SettingsFilePath = "appsettings.json";
 
-        public event Action<string> ThemeChanged;
-        public event Action<string> WindowModeChanged;
-        public event Action<IPieceImageStrategy> PieceSkinChanged;
+        public event Action<string>? WindowModeChanged;
+        public event Action<IPieceImageStrategy>? PieceSkinChanged;
 
         public AppSettings? Settings { get; private set; }
         private readonly JsonSerializerOptions jsonSerializerOptions = new() { WriteIndented = true };
@@ -49,8 +48,6 @@ namespace ChessGameApplication
         {
             Instance.Settings!.Theme = theme;
             Instance.Save();
-
-            Instance.ThemeChanged?.Invoke(theme);
         }
         public static void SetWindowMode(string windowMode)
         {

--- a/ChessGameApplication/Windows/GameWindow.xaml.cs
+++ b/ChessGameApplication/Windows/GameWindow.xaml.cs
@@ -27,10 +27,12 @@ namespace ChessGameApplication.Windows
 
         private readonly IWindowManager Manager;
         private readonly GameManager Game;
-        public GameWindow(IWindowManager manager, IPieceImageStrategy imageStrategy)
+        public GameWindow(IWindowManager manager)
         {
+            SettingsManager.Instance.PieceSkinChanged += OnPieceSkinChanged;
+
             Manager = manager;
-            Game = new GameManager(imageStrategy);
+            Game = new GameManager();
 
             InitializeComponent();
             RenderChessBoard();
@@ -166,6 +168,18 @@ namespace ChessGameApplication.Windows
             return (pos.Row + pos.Column) % 2 == 0
                 ? lightCell
                 : darkCell;
+        }
+        private void OnPieceSkinChanged(IPieceImageStrategy newStrategy)
+        {
+            Game.UpdateImageStrategy(newStrategy);
+
+            RenderChessBoard();
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            SettingsManager.Instance.PieceSkinChanged -= OnPieceSkinChanged;
+            base.OnClosed(e);
         }
     }
 }

--- a/ChessGameApplication/Windows/GameWindow.xaml.cs
+++ b/ChessGameApplication/Windows/GameWindow.xaml.cs
@@ -27,12 +27,12 @@ namespace ChessGameApplication.Windows
 
         private readonly IWindowManager Manager;
         private readonly GameManager Game;
-        public GameWindow(IWindowManager manager)
+        public GameWindow(IWindowManager manager, IPieceImageStrategy imageStrategy)
         {
             SettingsManager.Instance.PieceSkinChanged += OnPieceSkinChanged;
 
             Manager = manager;
-            Game = new GameManager();
+            Game = new GameManager(imageStrategy);
 
             InitializeComponent();
             RenderChessBoard();

--- a/ChessGameApplication/Windows/GameWindow.xaml.cs
+++ b/ChessGameApplication/Windows/GameWindow.xaml.cs
@@ -18,7 +18,7 @@ using ChessGameApplication.Game.PieceImageStrategies;
 
 namespace ChessGameApplication.Windows
 {
-    public partial class GameWindow : Window
+    public partial class GameWindow : Window, IChangeWindowMode
     {
         private readonly SolidColorBrush lightCell = new SolidColorBrush(Color.FromRgb(240, 217, 181));
         private readonly SolidColorBrush darkCell = new SolidColorBrush(Color.FromRgb(181, 136, 99));
@@ -30,6 +30,7 @@ namespace ChessGameApplication.Windows
         public GameWindow(IWindowManager manager, IPieceImageStrategy imageStrategy)
         {
             SettingsManager.Instance.PieceSkinChanged += OnPieceSkinChanged;
+            SettingsManager.Instance.WindowModeChanged += OnWindowModeChanged;
 
             Manager = manager;
             Game = new GameManager(imageStrategy);
@@ -175,10 +176,35 @@ namespace ChessGameApplication.Windows
 
             RenderChessBoard();
         }
+        private void OnWindowModeChanged(string mode)
+        {
+            ChangeWindowMode(mode);
+        }
+        private void ChangeWindowMode(string mode)
+        {
+            switch (mode)
+            {
+                case "Windowed":
+                    WindowState = WindowState.Normal;
+                    WindowStyle = WindowStyle.SingleBorderWindow;
+                    ResizeMode = ResizeMode.CanResizeWithGrip;
+                    Topmost = false;
+                    Width = 1280;
+                    Height = 800;
+                    break;
+                case "Fullscreen":
+                    WindowState = WindowState.Maximized;
+                    WindowStyle = WindowStyle.None;
+                    ResizeMode = ResizeMode.NoResize;
+                    Topmost = true;
+                    break;
+            }
+        }
 
         protected override void OnClosed(EventArgs e)
         {
             SettingsManager.Instance.PieceSkinChanged -= OnPieceSkinChanged;
+            SettingsManager.Instance.WindowModeChanged -= OnWindowModeChanged;
             base.OnClosed(e);
         }
     }

--- a/ChessGameApplication/Windows/GameWindow.xaml.cs
+++ b/ChessGameApplication/Windows/GameWindow.xaml.cs
@@ -180,7 +180,7 @@ namespace ChessGameApplication.Windows
         {
             ChangeWindowMode(mode);
         }
-        private void ChangeWindowMode(string mode)
+        public void ChangeWindowMode(string mode)
         {
             switch (mode)
             {

--- a/ChessGameApplication/Windows/IChangeWindowMode.cs
+++ b/ChessGameApplication/Windows/IChangeWindowMode.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ChessGameApplication.Windows
+{
+    public interface IChangeWindowMode
+    {
+        void ChangeWindowMode(string mode);
+    }
+}

--- a/ChessGameApplication/Windows/MainMenuWindow.xaml.cs
+++ b/ChessGameApplication/Windows/MainMenuWindow.xaml.cs
@@ -17,11 +17,13 @@ using System.Windows.Shapes;
 
 namespace ChessGameApplication.Windows
 {
-    public partial class MainMenuWindow : Window
+    public partial class MainMenuWindow : Window, IChangeWindowMode
     {
         private readonly IWindowManager Manager;
         public MainMenuWindow(IWindowManager manager)
         {
+            SettingsManager.Instance.WindowModeChanged += OnWindowModeChanged;
+
             Manager = manager;
 
             InitializeComponent();
@@ -44,6 +46,36 @@ namespace ChessGameApplication.Windows
         private void Exit_Click(object sender, RoutedEventArgs e)
         {
             Manager.Notify(WindowActions.Exit);
+        }
+        private void OnWindowModeChanged(string mode)
+        {
+            ChangeWindowMode(mode);
+        }
+        public void ChangeWindowMode(string mode)
+        {
+            switch (mode)
+            {
+                case "Windowed":
+                    WindowState = WindowState.Normal;
+                    WindowStyle = WindowStyle.SingleBorderWindow;
+                    ResizeMode = ResizeMode.CanResizeWithGrip;
+                    Topmost = false;
+                    Width = 1280;
+                    Height = 800;
+                    break;
+                case "Fullscreen":
+                    WindowState = WindowState.Maximized;
+                    WindowStyle = WindowStyle.None;
+                    ResizeMode = ResizeMode.NoResize;
+                    Topmost = true;
+                    break;
+            }
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            SettingsManager.Instance.WindowModeChanged -= OnWindowModeChanged;
+            base.OnClosed(e);
         }
     }
 }

--- a/ChessGameApplication/Windows/Manager/WindowManager.cs
+++ b/ChessGameApplication/Windows/Manager/WindowManager.cs
@@ -18,7 +18,7 @@ namespace ChessGameApplication.Windows.Manager
         public WindowManager()
         {
             settingsWindow = new SettingsWindow(this);
-            gameWindow = new GameWindow(this, SettingsManager.GetImageStrategy()!);
+            gameWindow = new GameWindow(this);
             mainMenuWindow = new MainMenuWindow(this);
         }
         public void Notify(WindowActions action)

--- a/ChessGameApplication/Windows/Manager/WindowManager.cs
+++ b/ChessGameApplication/Windows/Manager/WindowManager.cs
@@ -18,7 +18,7 @@ namespace ChessGameApplication.Windows.Manager
         public WindowManager()
         {
             settingsWindow = new SettingsWindow(this);
-            gameWindow = new GameWindow(this);
+            gameWindow = new GameWindow(this, SettingsManager.GetImageStrategy());
             mainMenuWindow = new MainMenuWindow(this);
         }
         public void Notify(WindowActions action)

--- a/ChessGameApplication/Windows/SettingsWindow.xaml
+++ b/ChessGameApplication/Windows/SettingsWindow.xaml
@@ -69,8 +69,8 @@
                           Name="WindowModeComboBox"
                           SelectionChanged="WindowModeComboBox_SelectionChanged" HorizontalAlignment="Right" VerticalAlignment="Center"
                           Style="{DynamicResource ComboBoxStyle}">
-                    <ComboBoxItem Content="Віконний" IsSelected="True"/>
-                    <ComboBoxItem Content="На весь екран"/>
+                    <ComboBoxItem Content="Віконний" Tag="Windowed"/>
+                    <ComboBoxItem Content="На весь екран" Tag="Fullscreen"/>
                 </ComboBox>
 
                 <TextBlock Text="Скін фігур:" 

--- a/ChessGameApplication/Windows/SettingsWindow.xaml.cs
+++ b/ChessGameApplication/Windows/SettingsWindow.xaml.cs
@@ -22,6 +22,7 @@ namespace ChessGameApplication.Windows
     {
         private AppSettings Settings;
         private readonly IWindowManager Manager;
+        private bool _isInitializing = true;
         public SettingsWindow(IWindowManager manager)
         {
             Manager = manager;
@@ -29,22 +30,13 @@ namespace ChessGameApplication.Windows
 
             InitializeComponent();
 
-
             ApplySkinSettings();
             ApplyWindowModeSettings();
             ApplyTheme();
+
+            _isInitializing = false;
         }
 
-        private void ThemeRadioButton_Checked(object sender, RoutedEventArgs e)
-        {
-            if (sender is not RadioButton radio || radio.Tag == null) return;
-
-            string themeTag = radio.Tag.ToString()!;
-
-            SettingsManager.SetTheme(themeTag);
-
-            ApplyTheme();
-        }
         private void ApplyTheme()
         {
             var themeActions = new Dictionary<string, Action>
@@ -70,7 +62,6 @@ namespace ChessGameApplication.Windows
                 throw new ArgumentException("Wrong theme selection");
             }
         }
-
         private void ApplyThemeResource(string path)
         {
             var dict = new ResourceDictionary
@@ -84,6 +75,16 @@ namespace ChessGameApplication.Windows
             Application.Current.Resources.MergedDictionaries.Remove(oldThemeDict);
             Application.Current.Resources.MergedDictionaries.Add(dict);
         }
+        private void ThemeRadioButton_Checked(object sender, RoutedEventArgs e)
+        {
+            if (_isInitializing) return;
+            if (sender is not RadioButton radio || radio.Tag == null) return;
+
+            string themeTag = radio.Tag.ToString()!;
+            SettingsManager.SetTheme(themeTag);
+            ApplyTheme();
+        }
+
         private void ApplyWindowModeSettings()
         {
             foreach (ComboBoxItem item in WindowModeComboBox.Items)
@@ -104,10 +105,6 @@ namespace ChessGameApplication.Windows
             }
         }
 
-        private void BackToMenu_Click(object sender, RoutedEventArgs e)
-        {
-            Manager.Notify(WindowActions.OpenMainMenu);
-        }
         private void ApplySkinSettings()
         {
             foreach (ComboBoxItem item in PieceSkinComboBox.Items)
@@ -126,6 +123,10 @@ namespace ChessGameApplication.Windows
                 string skinTag = selectedItem.Tag.ToString()!;
                 SettingsManager.SetPieceSkin(skinTag);
             }
+        }
+        private void BackToMenu_Click(object sender, RoutedEventArgs e)
+        {
+            Manager.Notify(WindowActions.OpenMainMenu);
         }
     }
 }

--- a/ChessGameApplication/Windows/SettingsWindow.xaml.cs
+++ b/ChessGameApplication/Windows/SettingsWindow.xaml.cs
@@ -29,6 +29,9 @@ namespace ChessGameApplication.Windows
 
             InitializeComponent();
 
+
+            ApplySkinSettings();
+            ApplyWindowModeSettings();
             ApplyTheme();
         }
 
@@ -41,7 +44,6 @@ namespace ChessGameApplication.Windows
             SettingsManager.SetTheme(themeTag);
 
             ApplyTheme();
-            ApplySkinSettings();
         }
         private void ApplyTheme()
         {
@@ -82,9 +84,24 @@ namespace ChessGameApplication.Windows
             Application.Current.Resources.MergedDictionaries.Remove(oldThemeDict);
             Application.Current.Resources.MergedDictionaries.Add(dict);
         }
+        private void ApplyWindowModeSettings()
+        {
+            foreach (ComboBoxItem item in WindowModeComboBox.Items)
+            {
+                if (item.Tag.ToString() == Settings.WindowMode)
+                {
+                    WindowModeComboBox.SelectedItem = item;
+                    break;
+                }
+            }
+        }
         private void WindowModeComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-
+            if (WindowModeComboBox.SelectedItem is ComboBoxItem selectedItem && selectedItem.Tag != null)
+            {
+                string modeTag = selectedItem.Tag.ToString()!;
+                SettingsManager.SetWindowMode(modeTag);
+            }
         }
 
         private void BackToMenu_Click(object sender, RoutedEventArgs e)

--- a/ChessGameApplication/Windows/SettingsWindow.xaml.cs
+++ b/ChessGameApplication/Windows/SettingsWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using ChessGameApplication.JsonModels;
+﻿using ChessGameApplication.Game.PieceImageStrategies;
+using ChessGameApplication.JsonModels;
 using ChessGameApplication.Windows.Manager;
 using System;
 using System.Collections.Generic;
@@ -18,13 +19,15 @@ using System.Windows.Shapes;
 
 namespace ChessGameApplication.Windows
 {
-    public partial class SettingsWindow : Window
+    public partial class SettingsWindow : Window, IChangeWindowMode
     {
         private AppSettings Settings;
         private readonly IWindowManager Manager;
         private bool _isInitializing = true;
         public SettingsWindow(IWindowManager manager)
         {
+            SettingsManager.Instance.WindowModeChanged += OnWindowModeChanged;
+
             Manager = manager;
             Settings = SettingsManager.Instance.Settings!;
 
@@ -123,6 +126,36 @@ namespace ChessGameApplication.Windows
                 string skinTag = selectedItem.Tag.ToString()!;
                 SettingsManager.SetPieceSkin(skinTag);
             }
+        }
+        private void OnWindowModeChanged(string mode)
+        {
+            ChangeWindowMode(mode);
+        }
+        public void ChangeWindowMode(string mode)
+        {
+            switch (mode)
+            {
+                case "Windowed":
+                    WindowState = WindowState.Normal;
+                    WindowStyle = WindowStyle.SingleBorderWindow;
+                    ResizeMode = ResizeMode.NoResize;
+                    Topmost = false;
+                    Width = 1280;
+                    Height = 800;
+                    break;
+                case "Fullscreen":
+                    WindowState = WindowState.Maximized;
+                    WindowStyle = WindowStyle.None;
+                    ResizeMode = ResizeMode.NoResize;
+                    Topmost = true;
+                    break;
+            }
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            SettingsManager.Instance.WindowModeChanged -= OnWindowModeChanged;
+            base.OnClosed(e);
         }
         private void BackToMenu_Click(object sender, RoutedEventArgs e)
         {


### PR DESCRIPTION
### Refactored SettingsManager with some kind of Observer pattern and created methods for changing window state for windows.

## Key Changes:
1. Refactored SettingsManager
+ Added kind of Observer patter to SettingsManager. Now this class provides [events](https://github.com/Shadocl-low/ChessGame/blob/bd5271d504a4bbef24f24225e54dccd17c20d6f3/ChessGameApplication/SettingsManager.cs#L18-L19) for subscribers and [triggering](https://github.com/Shadocl-low/ChessGame/blob/bd5271d504a4bbef24f24225e54dccd17c20d6f3/ChessGameApplication/SettingsManager.cs#L57) them.
+ Created events instead of manually calling methods of window.
2. Windows were subscribed to events
+ GameWindow [subscribed on](https://github.com/Shadocl-low/ChessGame/blob/bd5271d504a4bbef24f24225e54dccd17c20d6f3/ChessGameApplication/Windows/GameWindow.xaml.cs#L32-L33) PieceSkinChanged event. All windows subscribed on WindowModeChange.
3. Created [IChangeWindowMode](https://github.com/Shadocl-low/ChessGame/blob/bd5271d504a4bbef24f24225e54dccd17c20d6f3/ChessGameApplication/Windows/IChangeWindowMode.cs) interface
+ Created as a contract for windows. Window implements [method to change display mode](https://github.com/Shadocl-low/ChessGame/blob/bd5271d504a4bbef24f24225e54dccd17c20d6f3/ChessGameApplication/Windows/SettingsWindow.xaml.cs#L134-L153).

## Benefits:
+ Easier to manage setting's parameters for developer.
+ Siplyfied settings logic.