### PR TITLE
Createad indicators for players turns

### DIFF
--- a/ChessGameApplication/ChessGameApplication.csproj
+++ b/ChessGameApplication/ChessGameApplication.csproj
@@ -9,6 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Images\chess-player-one.png" />
+    <None Remove="Images\chess-player-two.png" />
     <None Remove="images\classic\bishop_dark.png" />
     <None Remove="images\classic\bishop_light.png" />
     <None Remove="images\classic\king_dark.png" />
@@ -36,6 +38,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Resource Include="Images\chess-player-one.png" />
+    <Resource Include="Images\chess-player-two.png" />
     <Resource Include="images\classic\bishop_dark.png" />
     <Resource Include="images\classic\bishop_light.png" />
     <Resource Include="images\classic\king_dark.png" />

--- a/ChessGameApplication/Windows/GameWindow.xaml
+++ b/ChessGameApplication/Windows/GameWindow.xaml
@@ -37,7 +37,7 @@
                    Width="75" Height="75"
                    VerticalAlignment="Top"
                    HorizontalAlignment="Center"
-                   Margin="0,100,0,0"/>
+                   Margin="0,100,0,0" Visibility="Collapsed"/>
 
             <Image x:Name="BottomTurnIndicator"
                    Grid.Row="1"
@@ -53,7 +53,8 @@
                     HorizontalAlignment="Center"
                     Width="300">
 
-            <TextBlock Text="Хід: Білий"
+            <TextBlock x:Name="TurnTextBlock"
+                       Text="Хід: Білий"
                        FontWeight="Bold"
                        Margin="0,0,0,30"
                        HorizontalAlignment="Center"

--- a/ChessGameApplication/Windows/GameWindow.xaml
+++ b/ChessGameApplication/Windows/GameWindow.xaml
@@ -10,6 +10,42 @@
         WindowStartupLocation="CenterScreen"
         Background="{DynamicResource WindowBackgroundBrush}"
         ResizeMode="CanResizeWithGrip">
+
+    <Window.Resources>
+        <Style TargetType="Image" x:Key="AnimatedImageStyle">
+            <Style.Triggers>
+                <!-- Анімація при появи (0 → 1) -->
+                <Trigger Property="IsVisible" Value="True">
+                    <Trigger.EnterActions>
+                        <BeginStoryboard>
+                            <Storyboard>
+                                <DoubleAnimation Storyboard.TargetProperty="Opacity"
+                                        From="0" To="1" 
+                                        Duration="0:0:0.3"/>
+                            </Storyboard>
+                        </BeginStoryboard>
+                    </Trigger.EnterActions>
+                </Trigger>
+
+                <Trigger Property="IsVisible" Value="False">
+                    <Trigger.EnterActions>
+                        <BeginStoryboard>
+                            <Storyboard>
+                                <DoubleAnimation Storyboard.TargetProperty="Opacity"
+                                        From="1" To="0" 
+                                        Duration="0:0:0.3"/>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Visibility">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0.3" 
+                                                   Value="{x:Static Visibility.Collapsed}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                            </Storyboard>
+                        </BeginStoryboard>
+                    </Trigger.EnterActions>
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+    </Window.Resources>
+    
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"/>
@@ -37,7 +73,7 @@
                    Width="75" Height="75"
                    VerticalAlignment="Top"
                    HorizontalAlignment="Center"
-                   Margin="0,100,0,0" Visibility="Collapsed"/>
+                   Margin="0,100,0,0" Opacity="1" Visibility="Collapsed"/>
 
             <Image x:Name="BottomTurnIndicator"
                    Grid.Row="1"
@@ -45,7 +81,7 @@
                    Width="75" Height="75"
                    VerticalAlignment="Bottom"
                    HorizontalAlignment="Center"
-                   Margin="0,0,0,100"/>
+                   Margin="0,0,0,100" Opacity="1"/>
         </Grid>
         
         <StackPanel Grid.Column="2"

--- a/ChessGameApplication/Windows/GameWindow.xaml
+++ b/ChessGameApplication/Windows/GameWindow.xaml
@@ -13,6 +13,7 @@
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
@@ -24,7 +25,30 @@
                      HorizontalAlignment="Center">
         </UniformGrid>
 
-        <StackPanel Grid.Column="1"
+        <Grid Grid.Column="1">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="50*"/>
+                <RowDefinition Height="50*"/>
+            </Grid.RowDefinitions>
+            
+            <Image x:Name="TopTurnIndicator"
+                   Grid.Row="0"
+                   Source="/images/chess-player-two.png"
+                   Width="75" Height="75"
+                   VerticalAlignment="Top"
+                   HorizontalAlignment="Center"
+                   Margin="0,100,0,0"/>
+
+            <Image x:Name="BottomTurnIndicator"
+                   Grid.Row="1"
+                   Source="/images/chess-player-one.png"
+                   Width="75" Height="75"
+                   VerticalAlignment="Bottom"
+                   HorizontalAlignment="Center"
+                   Margin="0,0,0,100"/>
+        </Grid>
+        
+        <StackPanel Grid.Column="2"
                     VerticalAlignment="Center"
                     HorizontalAlignment="Center"
                     Width="300">

--- a/ChessGameApplication/Windows/GameWindow.xaml.cs
+++ b/ChessGameApplication/Windows/GameWindow.xaml.cs
@@ -15,6 +15,7 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Xml.Linq;
 using ChessGameApplication.Game.PieceImageStrategies;
+using System.Windows.Media.Animation;
 
 namespace ChessGameApplication.Windows
 {
@@ -205,18 +206,18 @@ namespace ChessGameApplication.Windows
         {
             UpdateTurnIndicators();
         }
-        private void UpdateTurnIndicators()
+        private async void UpdateTurnIndicators()
         {
             if (Game.CurrentTurn == PieceColor.Black)
             {
-                TopTurnIndicator.Visibility = Visibility.Visible;
-                BottomTurnIndicator.Visibility = Visibility.Collapsed;
+                FadeIn(TopTurnIndicator);
+                FadeOut(BottomTurnIndicator);
                 TurnTextBlock.Text = "Хід: Чорний";
             }
             else
             {
-                TopTurnIndicator.Visibility = Visibility.Collapsed;
-                BottomTurnIndicator.Visibility = Visibility.Visible;
+                FadeOut(TopTurnIndicator);
+                FadeIn(BottomTurnIndicator);
                 TurnTextBlock.Text = "Хід: Білий";
             }
         }
@@ -225,6 +226,30 @@ namespace ChessGameApplication.Windows
             SettingsManager.Instance.PieceSkinChanged -= OnPieceSkinChanged;
             SettingsManager.Instance.WindowModeChanged -= OnWindowModeChanged;
             base.OnClosed(e);
+        }
+        private void AnimateOpacity(UIElement element, double from, double to, TimeSpan duration)
+        {
+            var animation = new DoubleAnimation
+            {
+                From = from,
+                To = to,
+                Duration = duration,
+                FillBehavior = FillBehavior.HoldEnd
+            };
+
+            element.BeginAnimation(UIElement.OpacityProperty, animation);
+        }
+        public void FadeIn(UIElement element)
+        {
+            element.Visibility = Visibility.Visible;
+            AnimateOpacity(element, 0, 1, TimeSpan.FromSeconds(0.3));
+        }
+        public async void FadeOut(UIElement element)
+        {
+            AnimateOpacity(element, 1, 0, TimeSpan.FromSeconds(0.3));
+
+            await Task.Delay(300);
+            element.Visibility = Visibility.Collapsed;
         }
     }
 }

--- a/ChessGameApplication/Windows/GameWindow.xaml.cs
+++ b/ChessGameApplication/Windows/GameWindow.xaml.cs
@@ -120,6 +120,7 @@ namespace ChessGameApplication.Windows
                     {
                         UpdateBoardAfterMove(_selectedPosition.Value, clickedPos);
                         ClearHighlights();
+                        OnTurnChanged();
                         _selectedPosition = null;
                     }
                 }
@@ -200,7 +201,25 @@ namespace ChessGameApplication.Windows
                     break;
             }
         }
-
+        private void OnTurnChanged()
+        {
+            UpdateTurnIndicators();
+        }
+        private void UpdateTurnIndicators()
+        {
+            if (Game.CurrentTurn == PieceColor.Black)
+            {
+                TopTurnIndicator.Visibility = Visibility.Visible;
+                BottomTurnIndicator.Visibility = Visibility.Collapsed;
+                TurnTextBlock.Text = "Хід: Чорний";
+            }
+            else
+            {
+                TopTurnIndicator.Visibility = Visibility.Collapsed;
+                BottomTurnIndicator.Visibility = Visibility.Visible;
+                TurnTextBlock.Text = "Хід: Білий";
+            }
+        }
         protected override void OnClosed(EventArgs e)
         {
             SettingsManager.Instance.PieceSkinChanged -= OnPieceSkinChanged;

--- a/ChessGameApplication/Windows/Manager/WindowManager.cs
+++ b/ChessGameApplication/Windows/Manager/WindowManager.cs
@@ -17,9 +17,9 @@ namespace ChessGameApplication.Windows.Manager
 
         public WindowManager()
         {
-            settingsWindow = new SettingsWindow(this);
             gameWindow = new GameWindow(this, SettingsManager.GetImageStrategy());
             mainMenuWindow = new MainMenuWindow(this);
+            settingsWindow = new SettingsWindow(this);
         }
         public void Notify(WindowActions action)
         {

--- a/ChessGameApplication/Windows/SettingsWindow.xaml
+++ b/ChessGameApplication/Windows/SettingsWindow.xaml
@@ -10,7 +10,7 @@
         Width="1280" Height="720"
         Background="{DynamicResource WindowBackgroundBrush}"
         ResizeMode="NoResize">
-
+    
     <Grid Margin="30">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>


### PR DESCRIPTION
### Created indicators for players turns with images and text blocks.

## Key Changes:
1. Added images
+ Now current players turn indicated with a [picture](https://github.com/Shadocl-low/ChessGame/blob/2f4d92e6a30a827c3cf22e77d3ac250094e3be28/ChessGameApplication/Windows/GameWindow.xaml#L64-L85) up or down.
2. Created [animation](https://github.com/Shadocl-low/ChessGame/blob/2f4d92e6a30a827c3cf22e77d3ac250094e3be28/ChessGameApplication/Windows/GameWindow.xaml.cs#L230-L253)
+ FadeIn and FadeOut animations for images.

## Benefits:
+ More comfort for user
+ Understanble user turns