### PR TITLE
Pawn transformation

### DIFF
--- a/ChessGameApplication/ChessGameApplication.csproj.user
+++ b/ChessGameApplication/ChessGameApplication.csproj.user
@@ -5,6 +5,9 @@
     <Compile Update="Windows\MainMenuWindow.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Update="Windows\PromotionDialog.xaml.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Update="Windows\SettingsWindow.xaml.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/ChessGameApplication/Game/Figures/Pawn.cs
+++ b/ChessGameApplication/Game/Figures/Pawn.cs
@@ -37,8 +37,8 @@ namespace ChessGameApplication.Game.Figures
         }
         public bool CanPromote()
         {
-            return (Color == PieceColor.White && Position.Row == 0) ||
-                   (Color == PieceColor.Black && Position.Row == 7);
+            return (Color == PieceColor.White && Position.Column == 0) ||
+                   (Color == PieceColor.Black && Position.Column == 7);
         }
     }
 }

--- a/ChessGameApplication/Game/Figures/Pawn.cs
+++ b/ChessGameApplication/Game/Figures/Pawn.cs
@@ -35,5 +35,10 @@ namespace ChessGameApplication.Game.Figures
 
             return moves;
         }
+        public bool CanPromote()
+        {
+            return (Color == PieceColor.White && Position.Row == 0) ||
+                   (Color == PieceColor.Black && Position.Row == 7);
+        }
     }
 }

--- a/ChessGameApplication/Game/Figures/PromotionPiece.cs
+++ b/ChessGameApplication/Game/Figures/PromotionPiece.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ChessGameApplication.Game.Figures
+{
+    public enum PromotionPiece
+    {
+        Queen,
+        Rook,
+        Bishop,
+        Knight
+    }
+}

--- a/ChessGameApplication/Game/GameManager.cs
+++ b/ChessGameApplication/Game/GameManager.cs
@@ -61,6 +61,38 @@ namespace ChessGameApplication.Game
                 Check?.Invoke();
             }
         }
+        private void PromotePawn(Position pawnPosition)
+        {
+            var pawn = Board.GetPieceAt(pawnPosition) as Pawn;
+            if (pawn == null) return;
+
+            // Створюємо вікно для вибору фігури
+            var promotionDialog = new PromotionDialog(pawn.Color);
+            if (promotionDialog.ShowDialog() == true)
+            {
+                Piece newPiece;
+                switch (promotionDialog.SelectedPiece)
+                {
+                    case PromotionPiece.Queen:
+                        newPiece = new Queen(pawn.Color, pawnPosition, _currentStrategy);
+                        break;
+                    case PromotionPiece.Rook:
+                        newPiece = new Rook(pawn.Color, pawnPosition, _currentStrategy);
+                        break;
+                    case PromotionPiece.Bishop:
+                        newPiece = new Bishop(pawn.Color, pawnPosition, _currentStrategy);
+                        break;
+                    case PromotionPiece.Knight:
+                        newPiece = new Knight(pawn.Color, pawnPosition, _currentStrategy);
+                        break;
+                    default:
+                        newPiece = new Queen(pawn.Color, pawnPosition, _currentStrategy);
+                        break;
+                }
+
+                Board.PlacePiece(newPiece, pawnPosition);
+            }
+        }
         public bool TryMakeMove(Position from, Position to)
         {
             if (IsGameOver) return false;
@@ -73,6 +105,11 @@ namespace ChessGameApplication.Game
                 return false;
 
             Board.MovePiece(from, to);
+
+            if (piece is Pawn pawn && pawn.CanPromote())
+            {
+                PromotePawn(pawn.Position);
+            }
 
             CheckGameEndConditions();
 

--- a/ChessGameApplication/Game/GameManager.cs
+++ b/ChessGameApplication/Game/GameManager.cs
@@ -90,6 +90,7 @@ namespace ChessGameApplication.Game
                         break;
                 }
 
+                newPiece.UpdateImage(_currentStrategy!);
                 Board.PlacePiece(newPiece, pawnPosition);
             }
         }

--- a/ChessGameApplication/Game/GameManager.cs
+++ b/ChessGameApplication/Game/GameManager.cs
@@ -1,5 +1,6 @@
 ﻿using ChessGameApplication.Game.Figures;
 using ChessGameApplication.Game.PieceImageStrategies;
+using ChessGameApplication.Windows;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -66,27 +67,26 @@ namespace ChessGameApplication.Game
             var pawn = Board.GetPieceAt(pawnPosition) as Pawn;
             if (pawn == null) return;
 
-            // Створюємо вікно для вибору фігури
-            var promotionDialog = new PromotionDialog(pawn.Color);
+            var promotionDialog = new PromotionDialog();
             if (promotionDialog.ShowDialog() == true)
             {
                 Piece newPiece;
                 switch (promotionDialog.SelectedPiece)
                 {
                     case PromotionPiece.Queen:
-                        newPiece = new Queen(pawn.Color, pawnPosition, _currentStrategy);
+                        newPiece = new Queen(pawn.Color, pawnPosition);
                         break;
                     case PromotionPiece.Rook:
-                        newPiece = new Rook(pawn.Color, pawnPosition, _currentStrategy);
+                        newPiece = new Rook(pawn.Color, pawnPosition);
                         break;
                     case PromotionPiece.Bishop:
-                        newPiece = new Bishop(pawn.Color, pawnPosition, _currentStrategy);
+                        newPiece = new Bishop(pawn.Color, pawnPosition);
                         break;
                     case PromotionPiece.Knight:
-                        newPiece = new Knight(pawn.Color, pawnPosition, _currentStrategy);
+                        newPiece = new Knight(pawn.Color, pawnPosition);
                         break;
                     default:
-                        newPiece = new Queen(pawn.Color, pawnPosition, _currentStrategy);
+                        newPiece = new Queen(pawn.Color, pawnPosition);
                         break;
                 }
 

--- a/ChessGameApplication/Windows/GameWindow.xaml
+++ b/ChessGameApplication/Windows/GameWindow.xaml
@@ -11,41 +11,6 @@
         Background="{DynamicResource WindowBackgroundBrush}"
         ResizeMode="CanResizeWithGrip">
 
-    <Window.Resources>
-        <Style TargetType="Image" x:Key="AnimatedImageStyle">
-            <Style.Triggers>
-                <!-- Анімація при появи (0 → 1) -->
-                <Trigger Property="IsVisible" Value="True">
-                    <Trigger.EnterActions>
-                        <BeginStoryboard>
-                            <Storyboard>
-                                <DoubleAnimation Storyboard.TargetProperty="Opacity"
-                                        From="0" To="1" 
-                                        Duration="0:0:0.3"/>
-                            </Storyboard>
-                        </BeginStoryboard>
-                    </Trigger.EnterActions>
-                </Trigger>
-
-                <Trigger Property="IsVisible" Value="False">
-                    <Trigger.EnterActions>
-                        <BeginStoryboard>
-                            <Storyboard>
-                                <DoubleAnimation Storyboard.TargetProperty="Opacity"
-                                        From="1" To="0" 
-                                        Duration="0:0:0.3"/>
-                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Visibility">
-                                    <DiscreteObjectKeyFrame KeyTime="0:0:0.3" 
-                                                   Value="{x:Static Visibility.Collapsed}"/>
-                                </ObjectAnimationUsingKeyFrames>
-                            </Storyboard>
-                        </BeginStoryboard>
-                    </Trigger.EnterActions>
-                </Trigger>
-            </Style.Triggers>
-        </Style>
-    </Window.Resources>
-    
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"/>

--- a/ChessGameApplication/Windows/GameWindow.xaml.cs
+++ b/ChessGameApplication/Windows/GameWindow.xaml.cs
@@ -196,7 +196,6 @@ namespace ChessGameApplication.Windows
                     WindowState = WindowState.Maximized;
                     WindowStyle = WindowStyle.None;
                     ResizeMode = ResizeMode.NoResize;
-                    Topmost = true;
                     break;
             }
         }

--- a/ChessGameApplication/Windows/PromotionDialog.xaml
+++ b/ChessGameApplication/Windows/PromotionDialog.xaml
@@ -1,0 +1,18 @@
+﻿<Window x:Class="ChessGameApplication.Windows.PromotionDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:ChessGameApplication.Windows"
+        mc:Ignorable="d"
+        Title="Оберіть фігуру" 
+        SizeToContent="WidthAndHeight"
+        WindowStartupLocation="CenterScreen"
+        ResizeMode="NoResize">
+    <StackPanel Orientation="Horizontal" Margin="10">
+        <Button x:Name="QueenButton" Content="Ферзь" Width="80" Height="80" Margin="5" Click="Queen_Click"/>
+        <Button x:Name="RookButton" Content="Тура" Width="80" Height="80" Margin="5" Click="Rook_Click"/>
+        <Button x:Name="BishopButton" Content="Слон" Width="80" Height="80" Margin="5" Click="Bishop_Click"/>
+        <Button x:Name="KnightButton" Content="Кінь" Width="80" Height="80" Margin="5" Click="Knight_Click"/>
+    </StackPanel>
+</Window>

--- a/ChessGameApplication/Windows/PromotionDialog.xaml
+++ b/ChessGameApplication/Windows/PromotionDialog.xaml
@@ -5,14 +5,39 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:ChessGameApplication.Windows"
         mc:Ignorable="d"
-        Title="Оберіть фігуру" 
+        Title="Оберіть фігуру"
+        Background="{DynamicResource WindowBackgroundBrush}"
         SizeToContent="WidthAndHeight"
         WindowStartupLocation="CenterScreen"
         ResizeMode="NoResize">
     <StackPanel Orientation="Horizontal" Margin="10">
-        <Button x:Name="QueenButton" Content="Ферзь" Width="80" Height="80" Margin="5" Click="Queen_Click"/>
-        <Button x:Name="RookButton" Content="Тура" Width="80" Height="80" Margin="5" Click="Rook_Click"/>
-        <Button x:Name="BishopButton" Content="Слон" Width="80" Height="80" Margin="5" Click="Bishop_Click"/>
-        <Button x:Name="KnightButton" Content="Кінь" Width="80" Height="80" Margin="5" Click="Knight_Click"/>
+        <Button x:Name="QueenButton" 
+                Content="Ферзь" 
+                Tag="0"
+                Width="80" Height="80" 
+                Margin="5" 
+                Click="Button_Click"
+                Style="{DynamicResource ButtonStyle}"/>
+        <Button x:Name="RookButton" 
+                Content="Тура" 
+                Tag="1"
+                Width="80" Height="80" 
+                Margin="5" 
+                Click="Button_Click"
+                Style="{DynamicResource ButtonStyle}"/>
+        <Button x:Name="BishopButton" 
+                Content="Слон"  
+                Tag="2"
+                Width="80" Height="80" 
+                Margin="5" 
+                Click="Button_Click"
+                Style="{DynamicResource ButtonStyle}"/>
+        <Button x:Name="KnightButton" 
+                Content="Кінь"  
+                Tag="3"
+                Width="80" Height="80" 
+                Margin="5" 
+                Click="Button_Click"
+                Style="{DynamicResource ButtonStyle}"/>
     </StackPanel>
 </Window>

--- a/ChessGameApplication/Windows/PromotionDialog.xaml.cs
+++ b/ChessGameApplication/Windows/PromotionDialog.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using ChessGameApplication.Game;
+using ChessGameApplication.Game.Figures;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -18,35 +19,17 @@ namespace ChessGameApplication.Windows
     public partial class PromotionDialog : Window
     {
         public PromotionPiece SelectedPiece { get; private set; }
-        private readonly PieceColor _color;
 
-        public PromotionDialog(PieceColor color)
+        public PromotionDialog()
         {
-            _color = color;
             InitializeComponent();
         }
 
-        private void Queen_Click(object sender, RoutedEventArgs e)
+        private void Button_Click(object sender, RoutedEventArgs e)
         {
-            SelectedPiece = PromotionPiece.Queen;
-            DialogResult = true;
-        }
+            var button = sender as Button;
 
-        private void Rook_Click(object sender, RoutedEventArgs e)
-        {
-            SelectedPiece = PromotionPiece.Rook;
-            DialogResult = true;
-        }
-
-        private void Bishop_Click(object sender, RoutedEventArgs e)
-        {
-            SelectedPiece = PromotionPiece.Bishop;
-            DialogResult = true;
-        }
-
-        private void Knight_Click(object sender, RoutedEventArgs e)
-        {
-            SelectedPiece = PromotionPiece.Knight;
+            SelectedPiece = (PromotionPiece)button?.Content!;
             DialogResult = true;
         }
     }

--- a/ChessGameApplication/Windows/PromotionDialog.xaml.cs
+++ b/ChessGameApplication/Windows/PromotionDialog.xaml.cs
@@ -1,0 +1,53 @@
+﻿using ChessGameApplication.Game;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace ChessGameApplication.Windows
+{
+    public partial class PromotionDialog : Window
+    {
+        public PromotionPiece SelectedPiece { get; private set; }
+        private readonly PieceColor _color;
+
+        public PromotionDialog(PieceColor color)
+        {
+            _color = color;
+            InitializeComponent();
+        }
+
+        private void Queen_Click(object sender, RoutedEventArgs e)
+        {
+            SelectedPiece = PromotionPiece.Queen;
+            DialogResult = true;
+        }
+
+        private void Rook_Click(object sender, RoutedEventArgs e)
+        {
+            SelectedPiece = PromotionPiece.Rook;
+            DialogResult = true;
+        }
+
+        private void Bishop_Click(object sender, RoutedEventArgs e)
+        {
+            SelectedPiece = PromotionPiece.Bishop;
+            DialogResult = true;
+        }
+
+        private void Knight_Click(object sender, RoutedEventArgs e)
+        {
+            SelectedPiece = PromotionPiece.Knight;
+            DialogResult = true;
+        }
+    }
+}

--- a/ChessGameApplication/Windows/PromotionDialog.xaml.cs
+++ b/ChessGameApplication/Windows/PromotionDialog.xaml.cs
@@ -29,7 +29,7 @@ namespace ChessGameApplication.Windows
         {
             var button = sender as Button;
 
-            SelectedPiece = (PromotionPiece)button?.Content!;
+            SelectedPiece = (PromotionPiece)Convert.ToUInt32(button?.Tag);
             DialogResult = true;
         }
     }


### PR DESCRIPTION
### Now Pawn can transform at the end of the line.

## Key Changes:
1. Added promote method
+ GameManager's [method](https://github.com/Shadocl-low/ChessGame/blob/c8a69b87ac14bfc81736e63a8496e6da4afd81d1/ChessGameApplication/Game/GameManager.cs#L65-L96) that changes piece.
2. Delete garbage
+ Deleted [useless animation](https://github.com/Shadocl-low/ChessGame/blob/c8a69b87ac14bfc81736e63a8496e6da4afd81d1/ChessGameApplication/Windows/GameWindow.xaml).
3. Created new window
+ [Window](https://github.com/Shadocl-low/ChessGame/blob/c8a69b87ac14bfc81736e63a8496e6da4afd81d1/ChessGameApplication/Windows/PromotionDialog.xaml) for picking new piece.

## Benefits:
+ Realized all actual rules from the game