### PR TITLE
Fixed bug New Game doesn't resets field state

### DIFF
--- a/ChessGameApplication/Game/Board.cs
+++ b/ChessGameApplication/Game/Board.cs
@@ -13,9 +13,10 @@ namespace ChessGameApplication.Game
     public class Board
     {
         private readonly Piece?[,] Squares = new Piece?[8, 8];
-        private IPieceImageStrategy? ImageStrategy;
         public void Initialize()
         {
+            Array.Clear(Squares, 0, Squares.Length);
+
             var startingPieces = new (Type pieceType, int x, int y)[]
             {
                 (typeof(Rook), 0, 0), (typeof(Knight), 1, 0), (typeof(Bishop), 2, 0),
@@ -34,10 +35,6 @@ namespace ChessGameApplication.Game
                 PlacePiece(new Pawn(PieceColor.Black, new Position(x, 1)), new Position(x, 1));
                 PlacePiece(new Pawn(PieceColor.White, new Position(x, 6)), new Position(x, 6));
             }
-        }
-        public void SetStrategy(IPieceImageStrategy imageStrategy)
-        {
-            ImageStrategy = imageStrategy;
         }
         public void PlacePiece(Piece? piece, Position position)
         {

--- a/ChessGameApplication/Game/GameManager.cs
+++ b/ChessGameApplication/Game/GameManager.cs
@@ -24,8 +24,6 @@ namespace ChessGameApplication.Game
             _currentStrategy = imageStrategy;
 
             Board = new Board();
-
-            StartNewGame();
         }
         public void StartNewGame()
         {

--- a/ChessGameApplication/Windows/GameWindow.xaml.cs
+++ b/ChessGameApplication/Windows/GameWindow.xaml.cs
@@ -42,6 +42,12 @@ namespace ChessGameApplication.Windows
             InitializeComponent();
             RenderChessBoard();
         }
+        public void StartNewGame()
+        {
+            Game.StartNewGame();
+            UpdateTurnIndicators();
+            RenderChessBoard();
+        }
         private void RenderChessBoard()
         {
             ChessBoard.Children.Clear();
@@ -196,6 +202,7 @@ namespace ChessGameApplication.Windows
                     WindowState = WindowState.Maximized;
                     WindowStyle = WindowStyle.None;
                     ResizeMode = ResizeMode.NoResize;
+                    Topmost = true;
                     break;
             }
         }

--- a/ChessGameApplication/Windows/Manager/WindowManager.cs
+++ b/ChessGameApplication/Windows/Manager/WindowManager.cs
@@ -29,6 +29,7 @@ namespace ChessGameApplication.Windows.Manager
                     SwitchWindow(mainMenuWindow);
                     break;
                 case WindowActions.OpenGame:
+                    gameWindow.StartNewGame();
                     SwitchWindow(gameWindow);
                     break;
                 case WindowActions.OpenSettings:


### PR DESCRIPTION
### Now New Game button resets board state, pieces and player turn

## Key Changes:
1. Added [new actions](https://github.com/Shadocl-low/ChessGame/blob/2b36934ec88c89fed1397362ea6f4b31d2df30de/ChessGameApplication/Windows/GameWindow.xaml.cs#L45-L50) at WindowManager open Game
+ Now board initializes when New Game button pressed and renders.

## Benefits:
+ User can play a lot of games
+ Easy to restart game